### PR TITLE
feature/265 Containerize with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ If you have some suggestions, feel free to create an issue.
 
 ## Running Locally
 
+### With pnpm
+
 1. Install dependencies using pnpm:
 
 ```sh
@@ -83,6 +85,12 @@ cp .env.example .env.local
 
 ```sh
 pnpm dev
+```
+
+### With Docker and docker compose
+
+```sh
+pnpm docker-dev
 ```
 
 ## License

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+OPTS="-f ./docker/docker-compose.yml"
+
+docker-compose $OPTS down --volumes
+docker-compose $OPTS up -d db
+docker-compose $OPTS up -d web

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20 as base
+RUN npm install -g pnpm
+
+COPY ../ /app
+WORKDIR /app
+
+FROM base as base_build
+
+RUN sh -c 'yes | pnpm install'
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.7"
+
+services:
+  web:
+    build:
+      target: base_build
+      context: ../
+      dockerfile: ./docker/Dockerfile
+      args:
+        - BUILDKIT_INLINE_CACHE=1
+    ports:
+      - "3000:3000"
+    working_dir: /app
+    volumes:
+      - ../:/app
+      - ./.env.local:/app/.env.local
+    command: [
+        "pnpm",
+        "dev"
+    ]
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'db'
+      MYSQL_USER: 'user'
+      MYSQL_PASSWORD: 'password'
+      MYSQL_ROOT_PASSWORD: 'password'
+    ports:
+      - '3306:3306'
+    expose:
+      - '3306'
+    volumes:
+      - my-db:/var/lib/mysql
+
+# Names our volume
+volumes:
+  my-db:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "next start",
     "lint": "next lint",
     "preview": "next build && next start",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "docker-dev": "./docker-run.sh"
   },
   "dependencies": {
     "@editorjs/code": "^2.8.0",


### PR DESCRIPTION
This PR makes it possible to run the project with one command

```
pnpm docker-dev
```

Once the update to v14 is done
(https://github.com/shadcn-ui/taxonomy/pull/253)
I would be happy to add testing to it, so we can mock email sending and test the features of the app.

I hope it is useful. Thanks